### PR TITLE
Update modules.ini (xwindow, big_space)

### DIFF
--- a/config/polybar/modules.ini
+++ b/config/polybar/modules.ini
@@ -231,11 +231,15 @@ format-foreground = #989cff
 
 [module/xwindow]
 type = internal/xwindow
-label = %title:0:30:...
+label = %title:0:100:...%
 
 [module/space]
 type = custom/text
 content = " "
+
+[module/big_space]
+type = custom/text
+content = "    "
 
 [module/xkeyboard]
 type = internal/xkeyboard


### PR DESCRIPTION
Исправил модуль для отображения названия текущего окна, добавил большой пробел.
<img width="1918" height="1079" alt="2025-11-16_18-00" src="https://github.com/user-attachments/assets/7536c35a-b141-44f7-849c-a2adbb49bc70" />
<img width="1918" height="1079" alt="2025-11-16_18-01" src="https://github.com/user-attachments/assets/811371ae-1726-4ca7-bb11-76fca37d7fcd" />
